### PR TITLE
Build flags for supporting alternate hardware configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,24 @@ Use the following example task configuration to set tinygo flash as your default
         {
             "label": "tinygo flash",
             "type": "shell",
-            "command": "tinygo flash --target pico -size short -opt 1 ${workspaceRoot}/examples",
+            "command": "tinygo flash -tags europi --target pico -opt 1 ${workspaceRoot}/examples/clockwerk",
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
         }
     ]
+}
+```
+
+Also make sure your `settings.json` contains the europi build flag:
+
+```json
+{
+    "go.toolsEnvVars": {
+        ...
+        "GOFLAGS": "-tags=europi..."
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Use the following example task configuration to set tinygo flash as your default
 }
 ```
 
-Also make sure your `settings.json` contains the europi build flag:
+Also make sure your Workspace Settings `settings.json` contains the europi build flag:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install the TinyGo VSCode plugin
 Use the `tinygo flash` command while your pico is in BOOTSEL mode to compile the script and copy it to your attached EuroPi pico.
 
 ```shell
-tinygo flash --target pico examples/diagnostics.go
+tinygo flash -tags europi -target pico examples/diagnostics.go
 ```
 
 > **_NOTE:_** After the first time you flash your TinyGo program you will no longer need to reboot in BOOTSEL mode to flash your script. Sweet!
@@ -46,7 +46,7 @@ You can launch minicom to view the printed output:
 minicom -b 115200 -o -D /dev/ttyACM0
 ```
 
-## VSCode build task
+## Configuring VSCode build task
 
 Add the TinyGo flash command as your default build task:
 

--- a/board.go
+++ b/board.go
@@ -1,0 +1,11 @@
+//go:build europi
+
+package europi
+
+import "machine"
+
+var (
+	DisplayChannel = machine.I2C0
+	DisplayI2CSda  = machine.GPIO0
+	DisplayI2CScl  = machine.GPIO1
+)

--- a/board_rmx.go
+++ b/board_rmx.go
@@ -1,0 +1,11 @@
+//go:build europi_rmx
+
+package europi
+
+import "machine"
+
+var (
+	DisplayChannel = machine.I2C1
+	DisplayI2CSda  = machine.GPIO2
+	DisplayI2CScl  = machine.GPIO3
+)

--- a/europi.go
+++ b/europi.go
@@ -42,7 +42,7 @@ func New() EuroPi {
 	cv6 := NewOutput(machine.GPIO19, machine.PWM1)
 
 	return EuroPi{
-		Display: NewDisplay(machine.I2C0, machine.GPIO0, machine.GPIO1),
+		Display: NewDisplay(DisplayChannel, DisplayI2CSda, DisplayI2CScl),
 
 		DI: NewDI(machine.GPIO22),
 		AI: NewAI(machine.ADC0),


### PR DESCRIPTION
When DIY EuroPi modules use different GPIO pin configurations, we want to be able to easily support those different configurations without requiring a separate fork. This can be solved using the Go feature [build constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints) along with separate gpio configuration files with build constraint headers.

For example, we can define two files 1) `board.go` for the official hardware configuration and 2) `board_rmx.go` for the smd remix by [@luisgongod](https://github.com/luisgongod). The first line of the file will be `// go:build europi` and `// go:build europi_rmx` respectively.

With that in place, the EuroPiGo firmware can be build using the command:

```shell
tinygo build -tags europi --target pico examples/
```
or
```shell
tinygo build -tags europi_rmx --target pico examples/
``` 

In order to use this in VSCode, we will need to make a few adjustments to the VSCode settings.

Add "-tags europi" to tasks.json (or "-tags europi_rmx")

```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "tinygo flash",
            "type": "shell",
            "command": "tinygo flash -tags europi --target pico -opt 1 ${workspaceRoot}/examples/clockwerk",
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "problemMatcher": []
        }
    ]
}
```

Add the build constraint flag to `settings.json` (either "europi" or "europi_rmx"):

```
{
    "go.toolsEnvVars": {
        "GOROOT": "...",
        "GOFLAGS": "-tags=europi,cortexm,baremetal,linux,arm,rp2040,rp,pico,tinygo,math_big_pure_go,gc.conservative,scheduler.tasks,serial.usb"
    }
}
```

Now you can build and flash the firmware for either hardware configuration!